### PR TITLE
`discord-player-googlevideo`: add default export

### DIFF
--- a/packages/discord-player-googlevideo/package.json
+++ b/packages/discord-player-googlevideo/package.json
@@ -8,7 +8,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
Without this change I have this error msg:

```
node:internal/modules/esm/resolve:313
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/anri/Perso/Botanique/node_modules/discord-player-googlevideo/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:313:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:604:13)
    at resolveExports (node:internal/modules/cjs/loader:677:36)
    at Module._findPath (node:internal/modules/cjs/loader:744:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1404:27)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
    at Module._load (node:internal/modules/cjs/loader:1225:37)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```