### PR TITLE
refactor: use "tomorrow" label for next-day queue ending time

### DIFF
--- a/src/handlers/queue.ts
+++ b/src/handlers/queue.ts
@@ -1,8 +1,4 @@
-import {
-	addMilliseconds,
-	differenceInCalendarDays,
-	formatDistance,
-} from 'date-fns';
+import { addMilliseconds, formatDistance } from 'date-fns';
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
@@ -14,6 +10,7 @@ import {
 } from 'discord.js';
 import { type GuildQueue, QueueRepeatMode, type Track } from 'discord-player';
 import createQueueAwareComponentHandler from '../utils/createQueueAwareComponentHandler';
+import formatEndingTime from '../utils/formatEndingTime';
 import getTrackPosition from '../utils/getTrackPosition';
 import getTrackThumbnail from '../utils/getTrackThumbnail';
 import isObject from '../utils/isObject';
@@ -64,15 +61,8 @@ export default async function queueCommandHandler(
 
 	const now = new Date();
 	const afterQueueEnds = addMilliseconds(new Date(), queue.estimatedDuration);
-	const dayDifference = differenceInCalendarDays(afterQueueEnds, now);
 
-	const trackEndsAt = afterQueueEnds.toLocaleTimeString('pl', {
-		hour: '2-digit',
-		minute: '2-digit',
-	});
-
-	const endingTime =
-		dayDifference === 0 ? trackEndsAt : `${trackEndsAt} (+${dayDifference})`;
+	const endingTime = formatEndingTime(afterQueueEnds);
 
 	const isCached =
 		isObject(currentTrack.metadata) &&

--- a/src/utils/formatEndingTime.ts
+++ b/src/utils/formatEndingTime.ts
@@ -1,0 +1,21 @@
+import { differenceInCalendarDays } from 'date-fns';
+
+export default function formatEndingTime(estimatedEndTime: Date) {
+	const now = new Date();
+	const dayDifference = differenceInCalendarDays(estimatedEndTime, now);
+
+	const formattedTime = estimatedEndTime.toLocaleTimeString('pl', {
+		hour: '2-digit',
+		minute: '2-digit',
+	});
+
+	if (dayDifference === 0) {
+		return formattedTime;
+	}
+
+	if (dayDifference === 1) {
+		return `${formattedTime} (tomorrow)`;
+	}
+
+	return `${formattedTime} (+${dayDifference} days)`;
+}

--- a/src/utils/tests/formatEndingTime.test.ts
+++ b/src/utils/tests/formatEndingTime.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import formatEndingTime from '../formatEndingTime';
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date('2025-03-08T20:00:00'));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+it('should return only the time when the end is on the same day', () => {
+	const endTime = new Date('2025-03-08T23:45:00');
+	const result = formatEndingTime(endTime);
+
+	expect(result).toBe('23:45');
+});
+
+it('should append "(tomorrow)" when the end is the next calendar day', () => {
+	const endTime = new Date('2025-03-09T01:30:00');
+	const result = formatEndingTime(endTime);
+
+	expect(result).toBe('01:30 (tomorrow)');
+});
+
+it('should append "(+N days)" when the end is 2 or more days away', () => {
+	const endTime = new Date('2025-03-10T14:00:00');
+	const result = formatEndingTime(endTime);
+
+	expect(result).toBe('14:00 (+2 days)');
+});
+
+it('should handle 3+ day differences', () => {
+	const endTime = new Date('2025-03-13T08:00:00');
+	const result = formatEndingTime(endTime);
+
+	expect(result).toBe('08:00 (+5 days)');
+});


### PR DESCRIPTION
Extracts the queue ending time formatting from `queue.ts` into a dedicated `formatEndingTime` utility.

## Changes

The `(+1)` time zone-style notation is replaced with more intuitive labels (inspired by Slack):

| Scenario | Before | After |
|----------|--------|-------|
| Same day | `23:45` | `23:45` |
| Next day | `23:45 (+1)` | `23:45 (tomorrow)` |
| 2+ days | `23:45 (+3)` | `23:45 (+3 days)` |

## Files

- **New:** `src/utils/formatEndingTime.ts` — extracted formatting logic
- **New:** `src/utils/tests/formatEndingTime.test.ts` — 4 test cases
- **Modified:** `src/handlers/queue.ts` — uses new utility, removed `differenceInCalendarDays` import

All 977 tests pass ✅