### PR TITLE
Restore .pnpmfile.mjs workaround to fix broken CI

### DIFF
--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -1,0 +1,5 @@
+// Workaround for pnpm v11 beta bug: configDependencies trigger auto-loading of
+// .pnpmfile.mjs (due to "type": "module"), but missing-file error handling doesn't
+// catch Node's ERR_MODULE_NOT_FOUND. See pnpm/pnpm#10683.
+// Can be removed once the bug is fixed upstream.
+export default { hooks: {} };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ overrides:
 
 packageExtensionsChecksum: sha256-msO/d9y/ZDrg0AuAY9OMmOGxOk5tXh31KHTCQYU0cn4=
 
-pnpmfileChecksum: sha256-cf+5r3ZWOJxzgXmKavdmLHG0t5CZ2JP04zWHTtIHtJo=
+pnpmfileChecksum: sha256-XM3tYTTXdCtCJJbCt4Mo+nnkEw6NsmCGZ6pAngPtRqU=
 
 importers:
 


### PR DESCRIPTION
## Problem

`main` CI (Build and deploy) and Release have been failing since commit `21a9105` "Remove obsolete .pnpmfile.mjs workaround":

- **Release**: `[ERROR] Error during pnpmfile execution ... Cannot find module '.../.pnpmfile.mjs'` during `pnpm install --frozen-lockfile`.
- **Build and deploy**: `failed to compute cache key: "/.pnpmfile.mjs": not found` (the `Dockerfile` still `COPY`s the file).

All subsequent Renovate PRs also branch off this broken state.

## Root cause

The removal commit assumed pnpm 11.6.0 no longer auto-loads a pnpmfile via `configDependencies` (`@pnpm/plugin-esm-node-path`). That assumption is wrong for this version: pnpm still writes a `pnpmfileChecksum` into `pnpm-lock.yaml`, so frozen installs and the Docker build still try to load the now-deleted `.pnpmfile.mjs` and crash with `ERR_MODULE_NOT_FOUND`.

## Fix

- Restore the empty-hooks `.pnpmfile.mjs` workaround.
- Revert the lockfile `pnpmfileChecksum` to the value matching the restored file.

Verified locally that `pnpm install --frozen-lockfile` now passes (it failed before this change). This returns `main` to green; outstanding Renovate PRs can then be rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)