### PR TITLE
Fix CI after dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store/
 .env
 fly.toml
 dist/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ catalogMode: strict
 
 dedupePeers: true
 
+minimumReleaseAge: 1440
+
 catalogs:
   default:
     '@biomejs/biome': 2.5.10

--- a/src/handlers/tests/prompt.test.ts
+++ b/src/handlers/tests/prompt.test.ts
@@ -809,7 +809,7 @@ describe('/prompt command', () => {
 			await promptCommandHandler(interaction);
 
 			const embed = getEmbedFromCall(interaction, 'editReply');
-			expect((embed?.description as string).length).toBe(400);
+			expect(embed?.description).toHaveLength(400);
 		});
 
 		it('should prefer action confirmations over text reply when both present', async () => {

--- a/src/hooks/tests/useCommandHandlers.test.ts
+++ b/src/hooks/tests/useCommandHandlers.test.ts
@@ -71,26 +71,26 @@ it('should validate command against `RAW_COMMANDS` before proceeding', async () 
 it.each([
 	{ input: 'tic_tac_toe', expected: 'ticTacToe' },
 	{ input: 'help', expected: 'help' },
-])('should handle snake_case to camelCase conversion correctly for `$input` -> `$expected`', async ({
-	input,
-	expected,
-}) => {
-	const interaction = createMockInteraction(input);
+])(
+	'should handle snake_case to camelCase conversion correctly for `$input` -> `$expected`',
+	async ({ input, expected }) => {
+		const interaction = createMockInteraction(input);
 
-	await useCommandHandlers(interaction);
+		await useCommandHandlers(interaction);
 
-	expect(mockJoin).toHaveBeenCalledWith(
-		expect.any(String),
-		'handlers',
-		`${expected}.js`,
-	);
+		expect(mockJoin).toHaveBeenCalledWith(
+			expect.any(String),
+			'handlers',
+			`${expected}.js`,
+		);
 
-	expect(mockJoin).toHaveBeenCalledTimes(1);
-	const [dirname, folder, filename] = mockJoin.mock.calls[0];
-	expect(dirname).toMatch(/hooks$/);
-	expect(folder).toBe('handlers');
-	expect(filename).toBe(`${expected}.js`);
-});
+		expect(mockJoin).toHaveBeenCalledTimes(1);
+		const [dirname, folder, filename] = mockJoin.mock.calls[0];
+		expect(dirname).toMatch(/hooks$/);
+		expect(folder).toBe('handlers');
+		expect(filename).toBe(`${expected}.js`);
+	},
+);
 
 it('should handle lockdown permission denied for owner-only commands', async () => {
 	const interaction = createMockInteraction('maintenance', {

--- a/src/utils/tests/RedisQueryCache.test.ts
+++ b/src/utils/tests/RedisQueryCache.test.ts
@@ -194,18 +194,23 @@ describe('RedisQueryCache', () => {
 			['empty array', []],
 			['null', null],
 			['undefined', undefined],
-		])('should not cache when `tracks` is %s', async (_description, tracksValue) => {
-			const mockSearchResult = {
-				query: EXAMPLE_QUERY,
-				tracks: tracksValue,
-			} as unknown as SearchResult;
+		])(
+			'should not cache when `tracks` is %s',
+			async (_description, tracksValue) => {
+				const mockSearchResult = {
+					query: EXAMPLE_QUERY,
+					tracks: tracksValue,
+				} as unknown as SearchResult;
 
-			await redisQueryCache.addData(mockSearchResult);
+				await redisQueryCache.addData(mockSearchResult);
 
-			expect(vi.mocked(serialize)).not.toHaveBeenCalled();
-			expect(mockRedis.setex).not.toHaveBeenCalled();
-			expect(mockedExternalPlaylistCache.setTrackCount).not.toHaveBeenCalled();
-		});
+				expect(vi.mocked(serialize)).not.toHaveBeenCalled();
+				expect(mockRedis.setex).not.toHaveBeenCalled();
+				expect(
+					mockedExternalPlaylistCache.setTrackCount,
+				).not.toHaveBeenCalled();
+			},
+		);
 	});
 
 	describe('getData', () => {

--- a/src/utils/tests/createSmartInteractionHandler.test.ts
+++ b/src/utils/tests/createSmartInteractionHandler.test.ts
@@ -192,31 +192,34 @@ describe('createSmartInteractionHandler', () => {
 		['playerSkip', () => mockTrack],
 		['emptyQueue', () => undefined],
 		['queueDelete', () => undefined],
-	])('should ignore %s events from different guilds', async (eventName, getEventArgs) => {
-		const onTrackChange = vi.fn();
-		const onQueueEmpty = vi.fn();
+	])(
+		'should ignore %s events from different guilds',
+		async (eventName, getEventArgs) => {
+			const onTrackChange = vi.fn();
+			const onQueueEmpty = vi.fn();
 
-		createSmartInteractionHandler({
-			response: mockResponse as unknown as InteractionResponse<boolean>,
-			queue: mockQueue,
-			track: mockTrack,
-			onTrackChange,
-			onQueueEmpty,
-		});
+			createSmartInteractionHandler({
+				response: mockResponse as unknown as InteractionResponse<boolean>,
+				queue: mockQueue,
+				track: mockTrack,
+				onTrackChange,
+				onQueueEmpty,
+			});
 
-		const eventHandler = getEventHandler(eventName);
-		const differentGuildQueue = createDifferentGuildQueue();
-		const eventArgs = getEventArgs();
+			const eventHandler = getEventHandler(eventName);
+			const differentGuildQueue = createDifferentGuildQueue();
+			const eventArgs = getEventArgs();
 
-		if (eventArgs) {
-			await eventHandler?.(differentGuildQueue, eventArgs);
-		} else {
-			await eventHandler?.(differentGuildQueue);
-		}
+			if (eventArgs) {
+				await eventHandler?.(differentGuildQueue, eventArgs);
+			} else {
+				await eventHandler?.(differentGuildQueue);
+			}
 
-		expect(onTrackChange).not.toHaveBeenCalled();
-		expect(onQueueEmpty).not.toHaveBeenCalled();
-	});
+			expect(onTrackChange).not.toHaveBeenCalled();
+			expect(onQueueEmpty).not.toHaveBeenCalled();
+		},
+	);
 
 	describe('playerStart event handler', () => {
 		it('should not trigger when same track starts in empty queue', async () => {
@@ -312,25 +315,25 @@ describe('createSmartInteractionHandler', () => {
 		});
 	});
 
-	it.each([
-		'emptyQueue',
-		'queueDelete',
-	])('should trigger queue empty callback for %s event', async (eventName) => {
-		const onQueueEmpty = vi.fn();
+	it.each(['emptyQueue', 'queueDelete'])(
+		'should trigger queue empty callback for %s event',
+		async (eventName) => {
+			const onQueueEmpty = vi.fn();
 
-		createSmartInteractionHandler({
-			response: mockResponse as unknown as InteractionResponse<boolean>,
-			queue: mockQueue,
-			track: mockTrack,
-			onQueueEmpty,
-		});
+			createSmartInteractionHandler({
+				response: mockResponse as unknown as InteractionResponse<boolean>,
+				queue: mockQueue,
+				track: mockTrack,
+				onQueueEmpty,
+			});
 
-		const eventHandler = getEventHandler(eventName);
-		await eventHandler?.(mockQueue);
+			const eventHandler = getEventHandler(eventName);
+			await eventHandler?.(mockQueue);
 
-		expect(onQueueEmpty).toHaveBeenCalled();
-		expect(mockResponse.edit).toHaveBeenCalledWith({ components: [] });
-	});
+			expect(onQueueEmpty).toHaveBeenCalled();
+			expect(mockResponse.edit).toHaveBeenCalledWith({ components: [] });
+		},
+	);
 
 	describe('cleanup function', () => {
 		it('should prevent cleanup from triggering multiple times', async () => {


### PR DESCRIPTION
Align pnpm's minimum release age with Renovate's 24-hour stability gate, fix the Biome 2.5.10 diagnostics, and ignore pnpm's local virtual store.